### PR TITLE
Add macros that are included only in debug build

### DIFF
--- a/rtt-target/src/debug.rs
+++ b/rtt-target/src/debug.rs
@@ -1,0 +1,47 @@
+/// This module contains macros that work exactly like thier equivalents without `debug_*`
+
+/* From init.rs */
+
+/// The same as [`rtt_init`] macro but works only in debug
+///
+/// [`rtt_init`](crate::rtt_init)
+#[macro_export]
+macro_rules! debug_rtt_init {
+    ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rtt_init!($($arg)*); })
+}
+
+/// The same as [`rtt_init_default`] macro but works only in debug
+///
+/// [`rtt_init_default`](crate::rtt_init_default)
+#[macro_export]
+macro_rules! debug_rtt_init_default {
+    ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rtt_init_default!($($arg)*); })
+}
+
+/* From print.rs */
+
+/// The same as [`rtt_init_print`] macro but works only in debug
+///
+/// [`rtt_init_print`](crate::rtt_init_print)
+#[cfg(any(feature = "cortex-m", feature = "riscv"))]
+#[macro_export]
+macro_rules! debug_rtt_init_print {
+    ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rtt_init_print!($($arg)*); })
+}
+
+/// The same as [`rprintln`] macro but works only in debug
+///
+/// [`rprintln`](crate::rprintln)
+#[macro_export]
+macro_rules! debug_rprintln {
+    ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rprintln!($($arg)*); })   
+}
+
+/// The same as [`rprint`] macro but works only in debug
+///
+/// [`rprint`](crate::rprint)
+#[macro_export]
+macro_rules! debug_rprint {
+    ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rprint!($($arg)*); })   
+}
+

--- a/rtt-target/src/debug.rs
+++ b/rtt-target/src/debug.rs
@@ -1,4 +1,4 @@
-/// This module contains macros that work exactly like thier equivalents without `debug_*`
+//! This module contains macros that work exactly like thier equivalents without `debug_*`
 
 /* From init.rs */
 
@@ -34,7 +34,7 @@ macro_rules! debug_rtt_init_print {
 /// [`rprintln`](crate::rprintln)
 #[macro_export]
 macro_rules! debug_rprintln {
-    ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rprintln!($($arg)*); })   
+    ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rprintln!($($arg)*); })
 }
 
 /// The same as [`rprint`] macro but works only in debug
@@ -42,6 +42,5 @@ macro_rules! debug_rprintln {
 /// [`rprint`](crate::rprint)
 #[macro_export]
 macro_rules! debug_rprint {
-    ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rprint!($($arg)*); })   
+    ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rprint!($($arg)*); })
 }
-

--- a/rtt-target/src/lib.rs
+++ b/rtt-target/src/lib.rs
@@ -86,6 +86,11 @@
 //! when build with `--release`. It's save to use [`debug_rprintln`] and [`debug_rprint`] even if
 //! rtt was initialized with not debug rtt initialization function.
 //!
+//! Under the hood this use [debug-assertions] flag. Set this flag to true to include all debug
+//! macros also in release mode.
+//!
+//! [debug-assertions]: https://doc.rust-lang.org/cargo/reference/profiles.html#debug-assertions
+//!
 //! ```
 //! use rtt_target::{debug_rtt_init_print, debug_rprintln};
 //!
@@ -112,6 +117,8 @@ use ufmt_write::uWrite;
 #[macro_use]
 mod init;
 
+#[doc(hidden)]
+/// Public due to access from macro
 pub mod debug;
 /// Public due to access from macro
 #[doc(hidden)]

--- a/rtt-target/src/lib.rs
+++ b/rtt-target/src/lib.rs
@@ -82,11 +82,11 @@
 //! # Debug
 //!
 //! To use rtt functionality only in debug builds use macros prefixed with `debug_*`. They have
-//! exactly the same functionality as without debug - the only difference is they are removed
-//! when build with `--release`. It's save to use [`debug_rprintln`] and [`debug_rprint`] even if
-//! rtt was initialized with not debug rtt initialization function.
+//! exactly the same functionality as without debug - the only difference is that they are removed
+//! when built with `--release`. It's save to use [`debug_rprintln`] and [`debug_rprint`] even if
+//! rtt was initialized with [`rtt_init`] instead of [`debug_rtt_init`].
 //!
-//! Under the hood this use [debug-assertions] flag. Set this flag to true to include all debug
+//! Under the hood this uses the [`debug-assertions`] flag. Set this flag to true to include all debug
 //! macros also in release mode.
 //!
 //! [debug-assertions]: https://doc.rust-lang.org/cargo/reference/profiles.html#debug-assertions

--- a/rtt-target/src/lib.rs
+++ b/rtt-target/src/lib.rs
@@ -68,6 +68,7 @@
 //! therefore work exactly like the standard `println` style macros. They can be used from any
 //! context. The [`rtt_init_print`] convenience macro initializes printing on channel 0.
 //!
+//!
 //! ```
 //! use rtt_target::{rtt_init_print, rprintln};
 //!
@@ -75,6 +76,23 @@
 //!     rtt_init_print!();
 //!     loop {
 //!         rprintln!("Hello, world!");
+//!     }
+//! }
+//! ```
+//! # Debug
+//!
+//! To use rtt functionality only in debug builds use macros prefixed with `debug_*`. They have
+//! exactly the same functionality as without debug - the only difference is they are removed
+//! when build with `--release`. It's save to use [`debug_rprintln`] and [`debug_rprint`] even if
+//! rtt was initialized with not debug rtt initialization function.
+//!
+//! ```
+//! use rtt_target::{debug_rtt_init_print, debug_rprintln};
+//!
+//! fn main() -> ! {
+//!     debug_rtt_init_print!(); // nop in --release
+//!     loop {
+//!         debug_rprintln!("Hello, world!"); // not present in --release
 //!     }
 //! }
 //! ```
@@ -94,6 +112,7 @@ use ufmt_write::uWrite;
 #[macro_use]
 mod init;
 
+pub mod debug;
 /// Public due to access from macro
 #[doc(hidden)]
 pub mod rtt;

--- a/rtt-target/src/print.rs
+++ b/rtt-target/src/print.rs
@@ -6,7 +6,7 @@ use crate::{TerminalChannel, TerminalWriter, UpChannel};
 
 static PRINT_TERMINAL: Mutex<RefCell<Option<TerminalChannel>>> = Mutex::new(RefCell::new(None));
 
-/// Sets the channel to use for [`rprint`] and [`rprintln`].
+/// Sets the channel to use for [`rprint`], [`rprintln`], [`debug_rptint`] and [`debug_rprintln`].
 pub fn set_print_channel(channel: UpChannel) {
     critical_section::with(|cs| {
         *PRINT_TERMINAL.borrow_ref_mut(cs) = Some(TerminalChannel::new(UpChannel(channel.0)))


### PR DESCRIPTION
I think this can be a common thing to use rtt only for debug and remove it in release.

I wanted to hide this debug macros behind `debug` module but as far as I know this is currently not supported by rust.
I would consider to hide this macros behind `debug` feature that is enabled by default. 