### PR TITLE
Use atomic polyfill for targets missing atomic support

### DIFF
--- a/rtt-target/Cargo.toml
+++ b/rtt-target/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/mvirkkunen/rtt-target"
 
 [dependencies]
 ufmt-write = "0.1.0"
+atomic-polyfill = "0.1.4"
 
 # Platform specific stuff
 cortex-m = { version = "0.7.1", optional = true }

--- a/rtt-target/src/print.rs
+++ b/rtt-target/src/print.rs
@@ -2,7 +2,7 @@ use crate::{TerminalChannel, TerminalWriter, UpChannel};
 use core::fmt::{self, Write as _};
 use core::mem::MaybeUninit;
 use core::ptr;
-use core::sync::atomic::{AtomicPtr, Ordering};
+use atomic_polyfill::{AtomicPtr, Ordering};
 
 static CRITICAL_SECTION: AtomicPtr<CriticalSectionFunc> = AtomicPtr::new(core::ptr::null_mut());
 static mut PRINT_TERMINAL: MaybeUninit<TerminalChannel> = MaybeUninit::uninit();

--- a/rtt-target/src/rtt.rs
+++ b/rtt-target/src/rtt.rs
@@ -6,7 +6,7 @@ use crate::ChannelMode;
 use core::cmp::min;
 use core::fmt;
 use core::ptr;
-use core::sync::atomic::{fence, AtomicUsize, Ordering::SeqCst};
+use atomic_polyfill::{fence, AtomicUsize, Ordering::SeqCst};
 
 // Note: this is zero-initialized in the initialization macro so all zeros must be a valid value
 #[repr(C)]


### PR DESCRIPTION
Drops in emulated atomics for targets missing `core::sync::atomic`, on targets that do not have them natively.