### PR TITLE
small section related to read via RTT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,5 @@
 [workspace]
-members = [
-    "examples-cortex-m",
-    "rtt-target",
-    "panic-rtt-target",
-    "panic-test",
-]
+members = ["examples-cortex-m", "rtt-target", "panic-rtt-target", "panic-test"]
 
 [patch.crates-io]
 rtt-target = { path = "./rtt-target" }

--- a/examples-cortex-m/Cargo.toml
+++ b/examples-cortex-m/Cargo.toml
@@ -9,7 +9,7 @@ cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7"
 panic-halt = "0.2.0"
 rtt-target = { path = "../rtt-target" }
-ufmt = "0.1.0"
+ufmt = "0.2.0"
 
 [[bin]]
 name = "custom"

--- a/panic-rtt-target/Cargo.toml
+++ b/panic-rtt-target/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["no-std", "embedded", "debugging", "rtt"]
 license = "MIT"
 license-file = "../LICENSE"
 authors = ["Matti Virkkunen <mvirkkunen@gmail.com>"]
-repository = "https://github.com/mvirkkunen/rtt-target"
+repository = "https://github.com/probe-rs/rtt-target"
 
 [dependencies]
 rtt-target = "0.4.0"

--- a/panic-rtt-target/Cargo.toml
+++ b/panic-rtt-target/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Matti Virkkunen <mvirkkunen@gmail.com>"]
 repository = "https://github.com/mvirkkunen/rtt-target"
 
 [dependencies]
-rtt-target = "0.3.1"
+rtt-target = "0.4.0"
 
 # Platform specific stuff
 cortex-m = { version = "0.7.1", optional = true }

--- a/rtt-target/Cargo.toml
+++ b/rtt-target/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["no-std", "embedded", "debugging", "rtt"]
 license = "MIT"
 license-file = "../LICENSE"
 authors = ["Matti Virkkunen <mvirkkunen@gmail.com>"]
-repository = "https://github.com/mvirkkunen/rtt-target"
+repository = "https://github.com/probe-rs/rtt-target"
 
 [dependencies]
 ufmt-write = "0.1.0"

--- a/rtt-target/Cargo.toml
+++ b/rtt-target/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rtt-target"
 description = "Target side implementation of the RTT (Real-Time Transfer) I/O protocol"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2018"
 readme = "../README.md"
 keywords = ["no-std", "embedded", "debugging", "rtt"]
@@ -13,4 +13,3 @@ repository = "https://github.com/mvirkkunen/rtt-target"
 [dependencies]
 ufmt-write = "0.1.0"
 critical-section = "1.0.0"
-

--- a/rtt-target/src/lib.rs
+++ b/rtt-target/src/lib.rs
@@ -116,24 +116,16 @@
 //! use rtt_target::{rtt_init_default, rprintln};
 //!
 //! fn main() -> ! {
-//!     let mut channels = rtt_init_default!();
-//!     let mut read_buf: [u8; 16] = [0; 16];
-//!     set_print_channel(channels.up.0);
-//!     rprintln!("Please enter the mode [0: Mode 0, 1: Mode 1]: ");
-//!     let mut read = 0;
-//!     let mut mode = None;
-//!     while mode.is_none() {
+//!     let mode = loop {
 //!         read = channels.down.0.read(&mut read_buf);
 //!         for i in 0..read {
-//!             let val = read_buf[i] as char;
-//!             if val == '0' {
-//!                 mode = Some(0);
-//!             } else if val == '1' {
-//!                 mode = Some(1);
+//!             match read_buf[i] as char {
+//!                 '0' => break 0,
+//!                 '1' => break 1,
+//!                 _ => {}
 //!             }
 //!         }
-//!     }
-//!     rprintln!("Read mode {}", mode);
+//!     };
 //! }
 //! ```
 

--- a/rtt-target/src/lib.rs
+++ b/rtt-target/src/lib.rs
@@ -121,15 +121,15 @@
 //!     set_print_channel(channels.up.0);
 //!     rprintln!("Please enter the mode [0: Mode 0, 1: Mode 1]: ");
 //!     let mut read = 0;
-//!     let mut mode = -1;
-//!     while mode == -1 {
+//!     let mut mode = None;
+//!     while mode.is_none() {
 //!         read = channels.down.0.read(&mut read_buf);
 //!         for i in 0..read {
 //!             let val = read_buf[i] as char;
 //!             if val == '0' {
-//!                 mode = 0;
+//!                 mode = Some(0);
 //!             } else if val == '1' {
-//!                 mode = 1;
+//!                 mode = Some(1);
 //!             }
 //!         }
 //!     }

--- a/rtt-target/src/lib.rs
+++ b/rtt-target/src/lib.rs
@@ -106,6 +106,36 @@
 //!
 //! Please note that because a critical section is used, printing into a blocking channel will cause
 //! the application to block and freeze when the buffer is full.
+//!
+//! # Reading
+//!
+//! The following example shows how to set up the RTT to read simple input sent from the host
+//! to the target.
+//!
+//! ```
+//! use rtt_target::{rtt_init_default, rprintln};
+//!
+//! fn main() -> ! {
+//!     let mut channels = rtt_init_default!();
+//!     let mut read_buf: [u8; 16] = [0; 16];
+//!     set_print_channel(channels.up.0);
+//!     rprintln!("Please enter the mode [0: Mode 0, 1: Mode 1]: ");
+//!     let mut read = 0;
+//!     let mut mode = -1;
+//!     while mode == -1 {
+//!         read = channels.down.0.read(&mut read_buf);
+//!         for i in 0..read {
+//!             let val = read_buf[i] as char;
+//!             if val == '0' {
+//!                 mode = 0;
+//!             } else if val == '1' {
+//!                 mode = 1;
+//!             }
+//!         }
+//!     }
+//!     rprintln!("Read mode {}", mode);
+//! }
+//! ```
 
 #![no_std]
 

--- a/rtt-target/src/lib.rs
+++ b/rtt-target/src/lib.rs
@@ -177,6 +177,7 @@ impl UpChannel {
         UpChannel(channel)
     }
 
+    #[allow(clippy::mut_from_ref)]
     fn channel(&self) -> &mut rtt::RttChannel {
         unsafe { &mut *self.0 }
     }
@@ -234,7 +235,7 @@ impl UpChannel {
             static mut CONTROL_BLOCK: MaybeUninit<rtt::RttHeader>;
         }
 
-        if number >= (&*CONTROL_BLOCK.as_ptr()).max_up_channels() {
+        if number >= (*CONTROL_BLOCK.as_ptr()).max_up_channels() {
             return None;
         }
 
@@ -242,7 +243,7 @@ impl UpChannel {
         // correct channel.
         let ptr = (CONTROL_BLOCK.as_ptr().add(1) as *mut rtt::RttChannel).add(number);
 
-        if !(&*ptr).is_initialized() {
+        if !(*ptr).is_initialized() {
             return None;
         }
 

--- a/rtt-target/src/print.rs
+++ b/rtt-target/src/print.rs
@@ -18,7 +18,7 @@ pub fn set_print_channel(channel: UpChannel) {
 pub mod print_impl {
     use super::*;
 
-    fn with_writer<F: Fn(TerminalWriter) -> ()>(number: u8, f: F) {
+    fn with_writer<F: Fn(TerminalWriter)>(number: u8, f: F) {
         critical_section::with(|cs| {
             if let Some(term) = &mut *PRINT_TERMINAL.borrow_ref_mut(cs) {
                 f(term.write(number))


### PR DESCRIPTION
I think this doc section would be useful to have a basic example of reading some input from the host. This is great for interactive applications which rely on the RTT input to perform different tasks. Maybe some helper function to read newline separated data from the host would be useful as well (something like the `input()` function of python for example) but this might be out of the scope of the package.

UPDATE: I just saw that there is an example using the down channel as well. Maybe it would be a good idea to cross-reference these examples in the documentation as well?