### PR TITLE
add license-file to crate metadata

### DIFF
--- a/panic-rtt-target/Cargo.toml
+++ b/panic-rtt-target/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 readme = "README.md"
 keywords = ["no-std", "embedded", "debugging", "rtt"]
 license = "MIT"
+license-file = "../LICENSE"
 authors = ["Matti Virkkunen <mvirkkunen@gmail.com>"]
 repository = "https://github.com/mvirkkunen/rtt-target"
 

--- a/rtt-target/Cargo.toml
+++ b/rtt-target/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 readme = "../README.md"
 keywords = ["no-std", "embedded", "debugging", "rtt"]
 license = "MIT"
+license-file = "../LICENSE"
 authors = ["Matti Virkkunen <mvirkkunen@gmail.com>"]
 repository = "https://github.com/mvirkkunen/rtt-target"
 


### PR DESCRIPTION
This ensures the license text is included with published crates, which is a condition of the license itself.