### PR TITLE
Panic rtt target riscv

### DIFF
--- a/panic-rtt-target/Cargo.toml
+++ b/panic-rtt-target/Cargo.toml
@@ -15,6 +15,13 @@ rtt-target = "0.4.0"
 
 # Platform specific stuff
 cortex-m = { version = "0.7.1", optional = true }
+# riscv = { verison = "0.10.1", optional = true }
+critical-section = "1.1.1"
+
+[features]
+cortex-m = ["dep:cortex-m"]
+#riscv = ["dep:riscv"]
+riscv = []
 
 [package.metadata.docs.rs]
-features = ["cortex-m"]
+features = ["cortex-m", "riscv"]

--- a/panic-rtt-target/Cargo.toml
+++ b/panic-rtt-target/Cargo.toml
@@ -2,26 +2,17 @@
 name = "panic-rtt-target"
 description = "Logs panic messages over RTT using rtt-target"
 version = "0.1.2"
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 keywords = ["no-std", "embedded", "debugging", "rtt"]
 license = "MIT"
 license-file = "../LICENSE"
-authors = ["Matti Virkkunen <mvirkkunen@gmail.com>"]
+authors = [
+    "Matti Virkkunen <mvirkkunen@gmail.com>",
+    "Per Lindgren <per.lindgren@ltu.se>",
+]
 repository = "https://github.com/probe-rs/rtt-target"
 
 [dependencies]
 rtt-target = "0.4.0"
-
-# Platform specific stuff
-cortex-m = { version = "0.7.1", optional = true }
-# riscv = { verison = "0.10.1", optional = true }
 critical-section = "1.1.1"
-
-[features]
-cortex-m = ["dep:cortex-m"]
-#riscv = ["dep:riscv"]
-riscv = []
-
-[package.metadata.docs.rs]
-features = ["cortex-m", "riscv"]

--- a/panic-rtt-target/README.md
+++ b/panic-rtt-target/README.md
@@ -8,9 +8,9 @@ Logs panic messages over RTT. A companion crate for rtt-target.
 
 RTT must have been initialized by using one of the `rtt_init` macros. Otherwise you will get a linker error at compile time.
 
-Panics are always logged on channel 0. Upon panicking the channel mode is also automatically set to `BlockIfFull`, so that the full message will always be logged. If the code somehow manages to panic at runtime before RTT is initialized (quite unlikely), or if channel 0 doesn't exist, nothing is logged.
+Panics are always logged on channel 0. Upon panicking the channel mode is also automatically set to `BlockIfFull`, so that the full message will always be logged. If the code somehow manages to panic at runtime before RTT is initialized (quite unlikely), or if channel 0 doesn't exist, nothing is logged. 
 
-A platform feature such as `cortex-m` or `riscv` is required to use this crate.
+The panic handler runs in a non-returning [critical_section](https://docs.rs/critical-section/latest/critical_section/) which implementation should be provided by the user. 
 
 # Usage
 
@@ -18,7 +18,8 @@ Cargo.toml:
 
 ```toml
 [dependencies]
-panic-rtt-target = { version = "x.y.z", features = ["cortex-m"] }
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"]}
+panic-rtt-target = { version = "x.y.z" }
 ```
 
 main.rs:
@@ -34,5 +35,30 @@ fn main() -> ! {
     rtt_init_default!();
 
     panic!("Something has gone terribly wrong");
+}
+```
+
+## Implementation details
+
+The provided interrupt handler checks if RTT channel 0 is configured, writes the `info` and enters an infinite loop. If RTT channel 0 is not configured, the panic handler enters the *failed to get channel* infinite loop. The final state can be observed by breaking/halting the target. 
+```rust
+fn panic(info: &PanicInfo) -> ! {
+    critical_section::with(|_| {
+        if let Some(mut channel) = unsafe { UpChannel::conjure(0) } {
+            channel.set_mode(ChannelMode::BlockIfFull);
+
+            writeln!(channel, "{}", info).ok();
+        } else {
+            // failed to get channel, but not much else we can do but spin
+            loop {
+                compiler_fence(SeqCst);
+            }
+        }
+
+        // we should never leave critical section
+        loop {
+            compiler_fence(SeqCst);
+        }
+    })
 }
 ```

--- a/panic-rtt-target/README.md
+++ b/panic-rtt-target/README.md
@@ -10,7 +10,7 @@ RTT must have been initialized by using one of the `rtt_init` macros. Otherwise 
 
 Panics are always logged on channel 0. Upon panicking the channel mode is also automatically set to `BlockIfFull`, so that the full message will always be logged. If the code somehow manages to panic at runtime before RTT is initialized (quite unlikely), or if channel 0 doesn't exist, nothing is logged.
 
-A platform feature such as `cortex-m` is required to use this crate.
+A platform feature such as `cortex-m` or `riscv` is required to use this crate.
 
 # Usage
 

--- a/panic-rtt-target/src/lib.rs
+++ b/panic-rtt-target/src/lib.rs
@@ -69,10 +69,5 @@ fn panic(info: &PanicInfo) -> ! {
         loop {
             compiler_fence(SeqCst);
         }
-    });
-
-    // will in fact be unreachable
-    loop {
-        compiler_fence(SeqCst);
-    }
+    })
 }

--- a/panic-test/Cargo.toml
+++ b/panic-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "panic-test"
 version = "0.1.0"
 authors = ["Matti Virkkunen <mvirkkunen@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortex-m-rt = "0.7"

--- a/panic-test/Cargo.toml
+++ b/panic-test/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 cortex-m-rt = "0.7"
-panic-rtt-target = { path = "../panic-rtt-target", features = ["cortex-m"] }
+panic-rtt-target = { path = "../panic-rtt-target" }
 rtt-target = { path = "../rtt-target" }

--- a/rtt-target/src/rtt.rs
+++ b/rtt-target/src/rtt.rs
@@ -30,8 +30,12 @@ impl RttHeader {
         ptr::write_volatile(&mut self.max_down_channels, max_down_channels);
 
         // The ID is copied last to make it less likely an unfinished control block is detected by the host.
-        let s = b"SEGGER RTT\0\0\0\0\0\0";
-        ptr::copy_nonoverlapping(s as *const u8, self.id.as_mut_ptr(), s.len());
+        // To avoid the host from misinterpreting the location of the RttHeader, we don't store it verbatim.
+        let s = b"_EGGER RTT\0\0\0\0\0\0";
+        ptr::write_volatile(&mut self.id, *s);
+        // Fix `S` as first character
+        ptr::write_volatile(&mut self.id[0], b'S');
+
         fence(SeqCst);
     }
 


### PR DESCRIPTION
CS based `panic_rtt_target`.
- platform agnostic
- addressed comments
- updated example
- updated documentation
- avoid storing `SEGGER RTT` verbatim to avoid misinterpretation of RttHeader location

Fixed some minor issues in `rtt_target` to get it working.

