### PR TITLE
make init macros accept `expr` for `$size`, `path` for `$mode`

### DIFF
--- a/examples-cortex-m/src/bin/custom.rs
+++ b/examples-cortex-m/src/bin/custom.rs
@@ -4,26 +4,26 @@
 use core::fmt::Write;
 use cortex_m_rt::entry;
 use panic_halt as _;
-use rtt_target::rtt_init;
+use rtt_target::{rtt_init, ChannelMode::BlockIfFull};
 
 #[entry]
 fn main() -> ! {
     let channels = rtt_init! {
         up: {
             0: {
-                size: 512
-                mode: BlockIfFull
+                size: 512,
+                mode: BlockIfFull,
                 name: "Output zero"
             }
             1: {
-                size: 128
+                size: 128,
                 name: "Output one"
             }
         }
         down: {
             0: {
-                size: 512
-                mode: BlockIfFull
+                size: 512,
+                mode: BlockIfFull,
                 name: "Input zero"
             }
         }

--- a/examples-cortex-m/src/bin/print.rs
+++ b/examples-cortex-m/src/bin/print.rs
@@ -3,7 +3,7 @@
 
 use cortex_m_rt::entry;
 use panic_halt as _;
-use rtt_target::{rprintln, rtt_init_print};
+use rtt_target::{rprintln, rtt_init_print, ChannelMode::BlockIfFull};
 
 #[entry]
 fn main() -> ! {

--- a/rtt-target/src/init.rs
+++ b/rtt-target/src/init.rs
@@ -20,6 +20,7 @@ macro_rules! rtt_init_channels {
             size: $size:expr
             $(, mode: $mode:path )?
             $(, name: $name:literal )?
+            $(,)?
         }
         $($tail:tt)*
     ) => {

--- a/rtt-target/src/init.rs
+++ b/rtt-target/src/init.rs
@@ -17,9 +17,9 @@ macro_rules! rtt_init_channels {
     (
         $field:expr;
         $number:literal: {
-            size: $size:literal
-            $( mode: $mode:ident )?
-            $( name: $name:literal )?
+            size: $size:expr
+            $(, mode: $mode:path )?
+            $(, name: $name:literal )?
         }
         $($tail:tt)*
     ) => {
@@ -27,7 +27,7 @@ macro_rules! rtt_init_channels {
         $( name = concat!($name, "\0").as_bytes().as_ptr(); )?
 
         let mut mode = $crate::ChannelMode::NoBlockSkip;
-        $( mode = $crate::ChannelMode::$mode; )?
+        $( mode = $mode; )?
 
         $field[$number].init(name, mode, {
             static mut _RTT_CHANNEL_BUFFER: MaybeUninit<[u8; $size]> = MaybeUninit::uninit();
@@ -67,8 +67,8 @@ macro_rules! rtt_init_wrappers {
 /// let channels = rtt_init! {
 ///     up: {
 ///         0: { // channel number
-///             size: 1024 // buffer size in bytes
-///             mode: NoBlockSkip // mode (optional, default: NoBlockSkip, see enum ChannelMode)
+///             size: 1024, // buffer size in bytes
+///             mode: NoBlockSkip, // mode (optional, default: NoBlockSkip, see enum ChannelMode)
 ///             name: "Terminal" // name (optional, default: no name)
 ///         }
 ///         1: {
@@ -77,7 +77,7 @@ macro_rules! rtt_init_wrappers {
 ///     }
 ///     down: {
 ///         0: {
-///             size: 16
+///             size: 16,
 ///             name: "Terminal"
 ///         }
 ///     }
@@ -171,13 +171,13 @@ macro_rules! rtt_init {
 /// rtt_init! {
 ///     up: {
 ///         0: {
-///             size: 1024
+///             size: 1024,
 ///             name: "Terminal"
 ///         }
 ///     }
 ///     down: {
 ///         0: {
-///             size: 16
+///             size: 16,
 ///             name: "Terminal"
 ///         }
 ///     }
@@ -191,13 +191,13 @@ macro_rules! rtt_init_default {
         $crate::rtt_init! {
             up: {
                 0: {
-                    size: 1024
+                    size: 1024,
                     name: "Terminal"
                 }
             }
             down: {
                 0: {
-                    size: 16
+                    size: 16,
                     name: "Terminal"
                 }
             }

--- a/rtt-target/src/print.rs
+++ b/rtt-target/src/print.rs
@@ -144,12 +144,12 @@ macro_rules! rdbg {
 /// in bytes (default: 1024). See [`rtt_init`] for more details.
 #[macro_export]
 macro_rules! rtt_init_print {
-    ($mode:ident, $size:literal) => {
+    ($mode:path, $size:expr) => {
         let channels = $crate::rtt_init! {
             up: {
                 0: {
-                    size: $size
-                    mode: $mode
+                    size: $size,
+                    mode: $mode,
                     name: "Terminal"
                 }
             }
@@ -158,11 +158,12 @@ macro_rules! rtt_init_print {
         $crate::set_print_channel(channels.up.0);
     };
 
-    ($mode:ident) => {
+    ($mode:path) => {
         $crate::rtt_init_print!($mode, 1024);
     };
 
     () => {
+        use $crate::ChannelMode::NoBlockSkip;
         $crate::rtt_init_print!(NoBlockSkip, 1024);
     };
 }


### PR DESCRIPTION
Currently, `rtt_init_print!()` macro didn't really use `rtt_target::ChannelMode` enums. Users can be confused of the `rtt_init_print!(BlockIfFull, 1024)` syntax, that user won't able use `rtt_init_print!(ChannelMode::BlockIfFull, 1024)`, and when they `import rtt_target::ChannelMode::*`, compiler said it's a unused import.
So, this PR make *init macros* accept `$mode:path`, which let user use `rtt_init_print!(ChannelMode::BlockIfFull, 1024)` etc.
Also, this PR make `$size:expr`, which let users write `rtt_init_print!(ChannelMode::BlockIfFull, 2usize.pow(10))`.

And this PR is a breaking change, which require users add comma `,` at the end of each line of each channel of `rtt_init!()` macro (which make the syntax more like creating a regular struct).