### PR TITLE
Add flush function to `UpChannel`

### DIFF
--- a/rtt-target/src/lib.rs
+++ b/rtt-target/src/lib.rs
@@ -241,6 +241,20 @@ impl UpChannel {
 
         Some(UpChannel(ptr))
     }
+
+    /// Wait until all data has been read by the debugger.
+    ///
+    /// *Note: This means that if no debugger is connected or if it isn't reading the rtt data,*
+    /// *this function will wait indefinitely.*
+    pub fn flush(&self) {
+        loop {
+            let (write, read) = self.channel().read_pointers();
+            if write == read {
+                break;
+            }
+            core::hint::spin_loop();
+        }
+    }
 }
 
 impl fmt::Write for UpChannel {

--- a/rtt-target/src/rtt.rs
+++ b/rtt-target/src/rtt.rs
@@ -146,7 +146,7 @@ impl RttChannel {
         }
     }
 
-    fn read_pointers(&self) -> (usize, usize) {
+    pub(crate) fn read_pointers(&self) -> (usize, usize) {
         let write = self.write.load(SeqCst);
         let read = self.read.load(SeqCst);
 


### PR DESCRIPTION
I'm trying to make a defmt encoder on top of rtt target since I can't use `defmt_rtt` because I need other RTT channels.
The defmt impl wants a flush function and that's implemented here.

They also do a check whether the host is connected by looking if the mode is BlockingIfFull. However, that's only done for defmt channels. So I've skipped that step to generalize it better.