### PR TITLE
General overhaul and defmt support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["examples-cortex-m", "rtt-target", "panic-rtt-target", "panic-test"]
+resolver = "2"
 
 [patch.crates-io]
 rtt-target = { path = "./rtt-target" }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ fn main() {
 }
 ```
 
+For more information, please check out the [documentation](https://docs.rs/rtt-target).
+
 ## Development
 
 The examples-cortex-m and panic-test crates come with build files for the venerable STM32F103C8xx by default, but can be easily adapted for any chip as they contain only minimal platform-specific runtime code to get `fn main` to run.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ fn main() {
 }
 ```
 
+`rtt-target` also supports initializing multiple RTT channels, and even has a logger implementation
+for [`defmt`](https://defmt.ferrous-systems.com/) that can be used in conjunction with arbitrary
+channel setups. The `defmt` integration requires setting `features = ["defmt"]`, and the used
+channel needs to be manually configured with `set_defmt_channel`.
+
 For more information, please check out the [documentation](https://docs.rs/rtt-target).
 
 ## Development

--- a/examples-cortex-m/.cargo/config.toml
+++ b/examples-cortex-m/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "thumbv7m-none-eabi"
+
+[unstable]
+build-std = ["core"]

--- a/examples-cortex-m/Cargo.toml
+++ b/examples-cortex-m/Cargo.toml
@@ -4,12 +4,16 @@ version = "0.1.0"
 authors = ["Matti Virkkunen <mvirkkunen@gmail.com>"]
 edition = "2018"
 
+[features]
+defmt = ["dep:defmt", "rtt-target/defmt"]
+
 [dependencies]
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7"
 panic-halt = "0.2.0"
 rtt-target = { path = "../rtt-target" }
 ufmt = "0.2.0"
+defmt = { version = "0.3.0", optional = true }
 
 [[bin]]
 name = "custom"
@@ -19,3 +23,7 @@ name = "print"
 
 [[bin]]
 name = "ufmt"
+
+[[bin]]
+name = "defmt"
+required-features = ["defmt"]

--- a/examples-cortex-m/src/bin/defmt.rs
+++ b/examples-cortex-m/src/bin/defmt.rs
@@ -1,0 +1,27 @@
+#![no_std]
+#![no_main]
+
+use cortex_m_rt::entry;
+use panic_halt as _;
+use rtt_target::rtt_init;
+
+#[entry]
+fn main() -> ! {
+    let channels = rtt_init! {
+        up: {
+            0: {
+                size: 1024,
+                name: "defmt"
+            }
+        }
+    };
+
+    rtt_target::set_defmt_channel(channels.up.0);
+
+    let mut i = 0;
+    loop {
+        defmt::println!("Loop {}...", i);
+
+        i += 1;
+    }
+}

--- a/panic-rtt-target/Cargo.toml
+++ b/panic-rtt-target/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 readme = "README.md"
 keywords = ["no-std", "embedded", "debugging", "rtt"]
 license = "MIT"
-license-file = "../LICENSE"
 authors = [
     "Matti Virkkunen <mvirkkunen@gmail.com>",
     "Per Lindgren <per.lindgren@ltu.se>",
@@ -16,3 +15,4 @@ repository = "https://github.com/probe-rs/rtt-target"
 [dependencies]
 rtt-target = "0.5.0"
 critical-section = "1.1.1"
+portable-atomic = { version = "1.6.0", default-features = false }

--- a/panic-rtt-target/Cargo.toml
+++ b/panic-rtt-target/Cargo.toml
@@ -13,6 +13,6 @@ authors = [
 repository = "https://github.com/probe-rs/rtt-target"
 
 [dependencies]
-rtt-target = "0.5.0"
+rtt-target = {version = "0.6.0", path = "../rtt-target" }
 critical-section = "1.1.1"
 portable-atomic = { version = "1.6.0", default-features = false }

--- a/panic-rtt-target/Cargo.toml
+++ b/panic-rtt-target/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "panic-rtt-target"
 description = "Logs panic messages over RTT using rtt-target"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 readme = "README.md"
 keywords = ["no-std", "embedded", "debugging", "rtt"]

--- a/panic-rtt-target/README.md
+++ b/panic-rtt-target/README.md
@@ -8,9 +8,9 @@ Logs panic messages over RTT. A companion crate for rtt-target.
 
 RTT must have been initialized by using one of the `rtt_init` macros. Otherwise you will get a linker error at compile time.
 
-Panics are always logged on channel 0. Upon panicking the channel mode is also automatically set to `BlockIfFull`, so that the full message will always be logged. If the code somehow manages to panic at runtime before RTT is initialized (quite unlikely), or if channel 0 doesn't exist, nothing is logged. 
+Panics are always logged to the print channel. Upon panicking the channel mode is also automatically set to `BlockIfFull`, so that the full message will always be logged. If the code somehow manages to panic at runtime before RTT is initialized (quite unlikely), or if the print channel doesn't exist, nothing is logged.
 
-The panic handler runs in a non-returning [critical_section](https://docs.rs/critical-section) which implementation should be provided by the user. 
+The panic handler runs in a non-returning [critical_section](https://docs.rs/critical-section) which implementation should be provided by the user.
 
 # Usage
 
@@ -18,8 +18,8 @@ Cargo.toml:
 
 ```toml
 [dependencies]
-cortex-m = { version = "0.7.6", features = ["critical-section-single-core"]}
-panic-rtt-target = { version = "x.y.z" }
+rtt-target = "x.y.z"
+panic-rtt-target = "x.y.z"
 ```
 
 main.rs:
@@ -31,34 +31,9 @@ use panic_rtt_target as _;
 use rtt_target::rtt_init_default;
 
 fn main() -> ! {
-    // you can use any init macro as long as it creates channel 0
+    // you can use `rtt_init_print` or you can call `set_print_channel` after initialization.
     rtt_init_default!();
 
     panic!("Something has gone terribly wrong");
-}
-```
-
-## Implementation details
-
-The provided interrupt handler checks if RTT channel 0 is configured, writes the `info` and enters an infinite loop. If RTT channel 0 is not configured, the panic handler enters the *failed to get channel* infinite loop. The final state can be observed by breaking/halting the target. 
-```rust
-fn panic(info: &PanicInfo) -> ! {
-    critical_section::with(|_| {
-        if let Some(mut channel) = unsafe { UpChannel::conjure(0) } {
-            channel.set_mode(ChannelMode::BlockIfFull);
-
-            writeln!(channel, "{}", info).ok();
-        } else {
-            // failed to get channel, but not much else we can do but spin
-            loop {
-                compiler_fence(SeqCst);
-            }
-        }
-
-        // we should never leave critical section
-        loop {
-            compiler_fence(SeqCst);
-        }
-    })
 }
 ```

--- a/panic-rtt-target/src/lib.rs
+++ b/panic-rtt-target/src/lib.rs
@@ -3,12 +3,13 @@
 //! RTT must have been initialized by using one of the `rtt_init` macros. Otherwise you will get a
 //! linker error at compile time.
 //!
-//! Panics are always logged on channel 0. Upon panicking the channel mode is also automatically set
-//! to `BlockIfFull`, so that the full message will always be logged. If the code somehow manages to
-//! panic at runtime before RTT is initialized (quite unlikely), or if channel 0 doesn't exist,
-//! nothing is logged.
+//! Panics are always logged to the print channel. Upon panicking the channel mode is also
+//! automatically set to `BlockIfFull`, so that the full message will always be logged.
+//! If the code somehow manages to panic at runtime before RTT is initialized (quite unlikely),
+//! or if the print channel doesn't exist, nothing is logged.
 //!
-//! A platform feature such as `cortex-m` is required to use this crate.
+//! The panic handler runs in a non-returning [critical_section](https://docs.rs/critical-section)
+//! which implementation should be provided by the user.
 //!
 //! # Usage
 //!
@@ -16,7 +17,8 @@
 //!
 //! ```toml
 //! [dependencies]
-//! panic-rtt-target = { version = "x.y.z" }
+//! rtt-target = "x.y.z"
+//! panic-rtt-target = "x.y.z"
 //! ```
 //!
 //! main.rs:
@@ -28,7 +30,7 @@
 //! use rtt_target::rtt_init_default;
 //!
 //! fn main() -> ! {
-//!     // you can use any init macro as long as it creates channel 0
+//!     // you can use `rtt_init_print` or you can call `set_print_channel` after initialization.
 //!     rtt_init_default!();
 //!
 //!     panic!("Something has gone terribly wrong");

--- a/panic-rtt-target/src/lib.rs
+++ b/panic-rtt-target/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! panic-rtt-target = { version = "x.y.z", features = ["cortex-m"] }
+//! panic-rtt-target = { version = "x.y.z" }
 //! ```
 //!
 //! main.rs:

--- a/panic-test/.cargo/config.toml
+++ b/panic-test/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "thumbv7m-none-eabi"
+
+[unstable]
+build-std = ["core"]

--- a/rtt-target/Cargo.toml
+++ b/rtt-target/Cargo.toml
@@ -16,3 +16,5 @@ default = []
 ufmt-write = "0.1.0"
 critical-section = "1.0.0"
 portable-atomic = { version = "1.6.0", default-features = false }
+
+defmt = { version = "0.3.0", optional = true }

--- a/rtt-target/Cargo.toml
+++ b/rtt-target/Cargo.toml
@@ -6,10 +6,13 @@ edition = "2018"
 readme = "../README.md"
 keywords = ["no-std", "embedded", "debugging", "rtt"]
 license = "MIT"
-license-file = "../LICENSE"
 authors = ["Matti Virkkunen <mvirkkunen@gmail.com>"]
 repository = "https://github.com/probe-rs/rtt-target"
+
+[features]
+default = []
 
 [dependencies]
 ufmt-write = "0.1.0"
 critical-section = "1.0.0"
+portable-atomic = { version = "1.6.0", default-features = false }

--- a/rtt-target/Cargo.toml
+++ b/rtt-target/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rtt-target"
 description = "Target side implementation of the RTT (Real-Time Transfer) I/O protocol"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2018"
 readme = "../README.md"
 keywords = ["no-std", "embedded", "debugging", "rtt"]

--- a/rtt-target/src/debug.rs
+++ b/rtt-target/src/debug.rs
@@ -1,10 +1,10 @@
-//! This module contains macros that work exactly like thier equivalents without `debug_*`
+//! This module contains macros that work exactly like their equivalents without `debug_*`
 
 /* From init.rs */
 
 /// The same as [`rtt_init`] macro but works only in debug
 ///
-/// [`rtt_init`](crate::rtt_init)
+/// [`rtt_init`]: crate::rtt_init
 #[macro_export]
 macro_rules! debug_rtt_init {
     ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rtt_init!($($arg)*); })
@@ -12,7 +12,7 @@ macro_rules! debug_rtt_init {
 
 /// The same as [`rtt_init_default`] macro but works only in debug
 ///
-/// [`rtt_init_default`](crate::rtt_init_default)
+/// [`rtt_init_default`]: crate::rtt_init_default
 #[macro_export]
 macro_rules! debug_rtt_init_default {
     ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rtt_init_default!($($arg)*); })
@@ -22,7 +22,7 @@ macro_rules! debug_rtt_init_default {
 
 /// The same as [`rtt_init_print`] macro but works only in debug
 ///
-/// [`rtt_init_print`](crate::rtt_init_print)
+/// [`rtt_init_print`]: crate::rtt_init_print
 #[macro_export]
 macro_rules! debug_rtt_init_print {
     ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rtt_init_print!($($arg)*); })
@@ -30,7 +30,7 @@ macro_rules! debug_rtt_init_print {
 
 /// The same as [`rprintln`] macro but works only in debug
 ///
-/// [`rprintln`](crate::rprintln)
+/// [`rprintln`]: crate::rprintln
 #[macro_export]
 macro_rules! debug_rprintln {
     ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rprintln!($($arg)*); })
@@ -38,7 +38,7 @@ macro_rules! debug_rprintln {
 
 /// The same as [`rprint`] macro but works only in debug
 ///
-/// [`rprint`](crate::rprint)
+/// [`rprint`]: crate::rprint
 #[macro_export]
 macro_rules! debug_rprint {
     ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rprint!($($arg)*); })

--- a/rtt-target/src/debug.rs
+++ b/rtt-target/src/debug.rs
@@ -2,17 +2,13 @@
 
 /* From init.rs */
 
-/// The same as [`rtt_init`] macro but works only in debug
-///
-/// [`rtt_init`]: crate::rtt_init
+/// The same as [`rtt_init`](crate::rtt_init) macro but works only in debug
 #[macro_export]
 macro_rules! debug_rtt_init {
     ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rtt_init!($($arg)*); })
 }
 
-/// The same as [`rtt_init_default`] macro but works only in debug
-///
-/// [`rtt_init_default`]: crate::rtt_init_default
+/// The same as [`rtt_init_default`](crate::rtt_init_default) macro but works only in debug
 #[macro_export]
 macro_rules! debug_rtt_init_default {
     ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rtt_init_default!($($arg)*); })
@@ -20,25 +16,19 @@ macro_rules! debug_rtt_init_default {
 
 /* From print.rs */
 
-/// The same as [`rtt_init_print`] macro but works only in debug
-///
-/// [`rtt_init_print`]: crate::rtt_init_print
+/// The same as [`rtt_init_print`](crate::rtt_init_print) macro but works only in debug
 #[macro_export]
 macro_rules! debug_rtt_init_print {
     ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rtt_init_print!($($arg)*); })
 }
 
-/// The same as [`rprintln`] macro but works only in debug
-///
-/// [`rprintln`]: crate::rprintln
+/// The same as [`rprintln`](crate::rprintln) macro but works only in debug
 #[macro_export]
 macro_rules! debug_rprintln {
     ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rprintln!($($arg)*); })
 }
 
-/// The same as [`rprint`] macro but works only in debug
-///
-/// [`rprint`]: crate::rprint
+/// The same as [`rprint`](crate::rprint) macro but works only in debug
 #[macro_export]
 macro_rules! debug_rprint {
     ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::rprint!($($arg)*); })

--- a/rtt-target/src/defmt.rs
+++ b/rtt-target/src/defmt.rs
@@ -1,0 +1,67 @@
+use crate::UpChannel;
+use portable_atomic::{AtomicBool, Ordering};
+
+static mut CHANNEL: Option<UpChannel> = None;
+
+#[defmt::global_logger]
+struct Logger;
+
+/// Sets the channel to use for [`defmt`] macros.
+pub fn set_defmt_channel(channel: UpChannel) {
+    unsafe { CHANNEL = Some(channel) }
+}
+
+/// Global logger lock.
+static TAKEN: AtomicBool = AtomicBool::new(false);
+static mut CS_RESTORE: critical_section::RestoreState = critical_section::RestoreState::invalid();
+static mut ENCODER: defmt::Encoder = defmt::Encoder::new();
+
+unsafe impl defmt::Logger for Logger {
+    fn acquire() {
+        // safety: Must be paired with corresponding call to release(), see below
+        let restore = unsafe { critical_section::acquire() };
+
+        if TAKEN.load(Ordering::Relaxed) {
+            panic!("defmt logger taken reentrantly")
+        }
+
+        // no need for CAS because interrupts are disabled
+        TAKEN.store(true, Ordering::Relaxed);
+
+        // safety: accessing the `static mut` is OK because we have acquired a critical section.
+        unsafe { CS_RESTORE = restore };
+
+        // safety: accessing the `static mut` is OK because we have disabled interrupts.
+        unsafe { ENCODER.start_frame(do_write) }
+    }
+
+    unsafe fn flush() {}
+
+    unsafe fn release() {
+        // safety: accessing the `static mut` is OK because we have acquired a critical section.
+        ENCODER.end_frame(do_write);
+
+        // safety: accessing the `static mut` is OK because we have acquired a critical section.
+        TAKEN.store(false, Ordering::Relaxed);
+
+        // safety: accessing the `static mut` is OK because we have acquired a critical section.
+        let restore = CS_RESTORE;
+
+        // safety: Must be paired with corresponding call to acquire(), see above
+        critical_section::release(restore);
+    }
+
+    unsafe fn write(bytes: &[u8]) {
+        // safety: accessing the `static mut` is OK because we have disabled interrupts.
+        ENCODER.write(bytes, do_write);
+    }
+}
+
+fn do_write(bytes: &[u8]) {
+    unsafe {
+        let channel = core::ptr::addr_of_mut!(CHANNEL);
+        if let Some(Some(c)) = channel.as_mut() {
+            c.write(bytes);
+        }
+    }
+}

--- a/rtt-target/src/lib.rs
+++ b/rtt-target/src/lib.rs
@@ -9,8 +9,7 @@
 //!
 //! This crate is platform agnostic and can be used on any chip that supports background memory
 //! access via its debug interface. The printing macros require a critical section which is
-//! platform-dependent. Built-in ARM Cortex-M support can be enabled with the "cortex-m" feature,
-//! and RISC-V support can be enabled with the "riscv" feature.
+//! platform-dependent.
 //!
 //! To interface with RTT from the host computer, a debug probe such as an ST-Link or J-Link is
 //! required. The normal debug protocol (e.g. SWD) is used to access RTT, so no extra connections
@@ -86,7 +85,7 @@
 //! when built with `--release`. It's save to use [`debug_rprintln`] and [`debug_rprint`] even if
 //! rtt was initialized with [`rtt_init`] instead of [`debug_rtt_init`].
 //!
-//! Under the hood this uses the [`debug-assertions`] flag. Set this flag to true to include all debug
+//! Under the hood this uses the [debug-assertions] flag. Set this flag to true to include all debug
 //! macros also in release mode.
 //!
 //! [debug-assertions]: https://doc.rust-lang.org/cargo/reference/profiles.html#debug-assertions

--- a/rtt-target/src/lib.rs
+++ b/rtt-target/src/lib.rs
@@ -67,7 +67,6 @@
 //! therefore work exactly like the standard `println` style macros. They can be used from any
 //! context. The [`rtt_init_print`] convenience macro initializes printing on channel 0.
 //!
-//!
 //! ```
 //! use rtt_target::{rtt_init_print, rprintln};
 //!
@@ -78,7 +77,6 @@
 //!     }
 //! }
 //! ```
-//! # Debug
 //!
 //! To use rtt functionality only in debug builds use macros prefixed with `debug_*`. They have
 //! exactly the same functionality as without debug - the only difference is that they are removed
@@ -135,20 +133,22 @@ use core::fmt;
 use core::mem::MaybeUninit;
 use ufmt_write::uWrite;
 
-#[macro_use]
-mod init;
-
 #[doc(hidden)]
 /// Public due to access from macro
 pub mod debug;
+#[cfg(feature = "defmt")]
+mod defmt;
 /// Public due to access from macro
 #[doc(hidden)]
 pub mod rtt;
 
-#[macro_use]
+mod init;
 mod print;
 
 pub use print::*;
+
+#[cfg(feature = "defmt")]
+pub use defmt::set_defmt_channel;
 
 /// RTT up (target to host) channel
 ///

--- a/rtt-target/src/lib.rs
+++ b/rtt-target/src/lib.rs
@@ -117,11 +117,9 @@
 //! the application to block and freeze when the buffer is full.
 //!
 //! `rtt-target` also supports initializing multiple RTT channels, and even has a logger
-//! implementation for [`defmt`] that can be used in conjunction with arbitrary channel setups.
+//! implementation for [`defmt`](::defmt) that can be used in conjunction with arbitrary channel setups.
 //! The `defmt` integration requires setting `features = ["defmt"]`, and the used channel needs
 //! to be manually configured with [`set_defmt_channel`].
-//!
-//! [`defmt`]: ::defmt
 //!
 //! # Reading
 //!

--- a/rtt-target/src/lib.rs
+++ b/rtt-target/src/lib.rs
@@ -60,6 +60,18 @@
 //! needed when debugging. That way you will never end up with an application that freezes without a
 //! debugger connected.
 //!
+//! # Defmt integration
+//!
+//! The `defmt` crate can be used to format messages in a way that is more efficient and more
+//! informative than the standard `format!` macros. To use `defmt` with RTT, the `defmt` feature
+//! must be enabled, and the channel must be set up with [`set_defmt_channel`].
+//!
+//! ```toml
+//! [dependencies]
+//! defmt = { version = "0.3" }
+//! rtt-target = { version = "0.6", features = ["defmt"] }
+//! ```
+//!
 //! # Printing
 //!
 //! For no-hassle output the [`rprint`] and [`rprintln`] macros are provided. They use a single down
@@ -80,7 +92,7 @@
 //!
 //! To use rtt functionality only in debug builds use macros prefixed with `debug_*`. They have
 //! exactly the same functionality as without debug - the only difference is that they are removed
-//! when built with `--release`. It's save to use [`debug_rprintln`] and [`debug_rprint`] even if
+//! when built with `--release`. It's safe to use [`debug_rprintln`] and [`debug_rprint`] even if
 //! rtt was initialized with [`rtt_init`] instead of [`debug_rtt_init`].
 //!
 //! Under the hood this uses the [debug-assertions] flag. Set this flag to true to include all debug
@@ -103,6 +115,13 @@
 //!
 //! Please note that because a critical section is used, printing into a blocking channel will cause
 //! the application to block and freeze when the buffer is full.
+//!
+//! `rtt-target` also supports initializing multiple RTT channels, and even has a logger
+//! implementation for [`defmt`] that can be used in conjunction with arbitrary channel setups.
+//! The `defmt` integration requires setting `features = ["defmt"]`, and the used channel needs
+//! to be manually configured with [`set_defmt_channel`].
+//!
+//! [`defmt`]: ::defmt
 //!
 //! # Reading
 //!

--- a/rtt-target/src/lib.rs
+++ b/rtt-target/src/lib.rs
@@ -347,7 +347,9 @@ impl TerminalChannel {
     /// The correct way to use this method is to call it once for each write operation. This is so
     /// that non blocking modes will work correctly.
     ///
-    /// The writer supports formatted writing with the standard `write` and ufmt's `uwrite`.
+    /// The writer supports formatted writing with the standard [`Write`] and [`ufmt_write::uWrite`].
+    ///
+    /// [`Write`]: fmt::Write
     pub fn write(&mut self, number: u8) -> TerminalWriter {
         const TERMINAL_ID: [u8; 16] = *b"0123456789ABCDEF";
 

--- a/rtt-target/src/print.rs
+++ b/rtt-target/src/print.rs
@@ -6,10 +6,24 @@ use crate::{TerminalChannel, TerminalWriter, UpChannel};
 
 static PRINT_TERMINAL: Mutex<RefCell<Option<TerminalChannel>>> = Mutex::new(RefCell::new(None));
 
-/// Sets the channel to use for [`rprint`], [`rprintln`], [`debug_rptint`] and [`debug_rprintln`].
+/// Sets the channel to use for [`rprint`], [`rprintln`], [`debug_rprint`] and [`debug_rprintln`].
+///
+/// [`rprint`]: crate::rprint
+/// [`rprintln`]: crate::rprintln
+/// [`debug_rprint`]: crate::debug_rprint
+/// [`debug_rprintln`]: crate::debug_rprintln
 pub fn set_print_channel(channel: UpChannel) {
     critical_section::with(|cs| {
         *PRINT_TERMINAL.borrow_ref_mut(cs) = Some(TerminalChannel::new(UpChannel(channel.0)))
+    });
+}
+
+/// Allows working with the currently set print channel.
+pub fn with_terminal_channel<F: Fn(&mut TerminalChannel)>(f: F) {
+    critical_section::with(|cs| {
+        if let Some(term) = &mut *PRINT_TERMINAL.borrow_ref_mut(cs) {
+            f(term)
+        }
     });
 }
 
@@ -19,11 +33,7 @@ pub mod print_impl {
     use super::*;
 
     fn with_writer<F: Fn(TerminalWriter)>(number: u8, f: F) {
-        critical_section::with(|cs| {
-            if let Some(term) = &mut *PRINT_TERMINAL.borrow_ref_mut(cs) {
-                f(term.write(number))
-            }
-        });
+        with_terminal_channel(|term| f(term.write(number)));
     }
 
     /// Public due to access from macro.
@@ -49,8 +59,10 @@ pub mod print_impl {
 /// the channel isn't set, the message is silently discarded.
 ///
 /// The macro also supports output to multiple virtual terminals on the channel. Use the syntax
-/// ```rprint!(=> 1, "Hello!");``` to write to terminal number 1, for example. Terminal numbers
+/// `rprint!(=> 1, "Hello!");` to write to terminal number 1, for example. Terminal numbers
 /// range from 0 to 15.
+///
+/// [`rtt_init_print`]: crate::rtt_init_print
 #[macro_export]
 macro_rules! rprint {
     (=> $terminal:expr, $s:expr) => {
@@ -73,8 +85,10 @@ macro_rules! rprint {
 /// the channel isn't set, the message is silently discarded.
 ///
 /// The macro also supports output to multiple virtual terminals on the channel. Use the syntax
-/// ```rprintln!(=> 1, "Hello!");``` to write to terminal number 1, for example. Terminal numbers
+/// `rprintln!(=> 1, "Hello!");` to write to terminal number 1, for example. Terminal numbers
 /// range from 0 to 15.
+///
+/// [`rtt_init_print`]: crate::rtt_init_print
 #[macro_export]
 macro_rules! rprintln {
     (=> $terminal:expr) => {
@@ -142,6 +156,8 @@ macro_rules! rdbg {
 ///
 /// The optional arguments specify the blocking mode (default: `NoBlockSkip`) and size of the buffer
 /// in bytes (default: 1024). See [`rtt_init`] for more details.
+///
+/// [`rtt_init`]: crate::rtt_init
 #[macro_export]
 macro_rules! rtt_init_print {
     ($mode:path, $size:expr) => {

--- a/rtt-target/src/print.rs
+++ b/rtt-target/src/print.rs
@@ -18,7 +18,7 @@ pub fn set_print_channel(channel: UpChannel) {
     });
 }
 
-/// Allows working with the currently set print channel.
+/// Allows accessing the currently set print channel.
 pub fn with_terminal_channel<F: Fn(&mut TerminalChannel)>(f: F) {
     critical_section::with(|cs| {
         if let Some(term) = &mut *PRINT_TERMINAL.borrow_ref_mut(cs) {


### PR DESCRIPTION
This PR does a lot.
- Update documentation to fix links, add info
- Add `defmt` support, basically copy-pasted from `defmt-rtt-target` (well, my unmerged [PR](https://github.com/akiles/defmt-rtt-target/pull/2))
- Fix `panic-rtt-target` to always output to the active printing channel
- Adds a `.cargo/config.toml` to examples and test project to make building them simpler.